### PR TITLE
[BUGFIX] broken form finisher icon

### DIFF
--- a/Configuration/Yaml/FormEditorOverrides.yaml
+++ b/Configuration/Yaml/FormEditorOverrides.yaml
@@ -199,7 +199,7 @@ TYPO3:
                   10: 'EXT:form/Resources/Private/Frontend/Templates/Finishers/Email/'
                   20: 'EXT:form_double_opt_in/Resources/Private/Templates/Email/'
               formEditor:
-                iconIdentifier: 't3-form-icon-finisher'
+                iconIdentifier: form-finisher
                 label: 'Double Opt-In'
                 predefinedDefaults:
                   options:


### PR DESCRIPTION
We installed TYPO3 11.5.28 and noticed that the form finisher icon was broken.
current:
![grafik](https://github.com/linawolf/form_double_opt_in/assets/33951787/b1cc0c26-cb9f-4502-ae1d-8c67a6386039)

This fix seems to correct the issue.
![grafik](https://github.com/linawolf/form_double_opt_in/assets/33951787/98e32316-fd55-4449-9c7d-53b1f0dac99a)
